### PR TITLE
Link badges to PyPI and the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # A simple watcher for pytest
 
-![PyPI](https://img.shields.io/pypi/v/pytest-watcher)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytest-watcher)
-![GitHub](https://img.shields.io/github/license/olzhasar/pytest-watcher)
+[![PyPI](https://img.shields.io/pypi/v/pytest-watcher)](https://pypi.org/project/pytest-watcher/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytest-watcher)](https://pypi.org/project/pytest-watcher/)
+[![GitHub](https://img.shields.io/github/license/olzhasar/pytest-watcher)](https://github.com/olzhasar/pytest-watcher/blob/master/LICENSE)
 
 ## Overview
 


### PR DESCRIPTION
So that clicking them takes you to PyPI and the license instead of just badge images.

Preview:

https://github.com/hugovk/pytest-watcher/blob/011962f6712170c4128d79b62a997adc4b5a1777/README.md