### PR TITLE
Test on Python 3.10

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py36,py37,py38,py39
+envlist = py36,py37,py38,py39,py310
 
 [tox:.package]
 basepython = python3


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

```console
$ tox -e py310
.package create: /private/tmp/pytest-watcher/.tox/.package
.package installdeps: poetry-core>=1.0.0
py310 create: /private/tmp/pytest-watcher/.tox/py310
py310 installdeps: watchdog, pytest, pytest-mock, freezegun
py310 inst: /private/tmp/pytest-watcher/.tox/.tmp/package/1/pytest-watcher-0.2.1.tar.gz
py310 installed: attrs==21.2.0,freezegun==1.1.0,iniconfig==1.1.1,packaging==21.3,pluggy==1.0.0,py==1.11.0,pyparsing==3.0.6,pytest==6.2.5,pytest-mock==3.6.1,pytest-watcher @ file:///private/tmp/pytest-watcher/.tox/.tmp/package/1/pytest-watcher-0.2.1.tar.gz,python-dateutil==2.8.2,six==1.16.0,toml==0.10.2,watchdog==2.1.6
py310 run-test-pre: PYTHONHASHSEED='546577221'
py310 run-test: commands[0] | pytest
========================================================== test session starts ===========================================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
cachedir: .tox/py310/.pytest_cache
rootdir: /private/tmp/pytest-watcher
plugins: mock-3.6.1
collected 21 items

tests/test_pytest_watcher.py .....................                                                                                 [100%]

=========================================================== 21 passed in 0.75s ===========================================================
________________________________________________________________ summary _________________________________________________________________
  py310: commands succeeded
  congratulations :)
```