### PR TITLE
Feature: Adds new CLI parameter `entrypoint`

### DIFF
--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -63,7 +63,7 @@ class EventHandler(events.FileSystemEventHandler):
             emit_trigger()
 
 
-def _run_runner(runner: str, args: Sequence[str]) -> None:
+def _invoke_runner(runner: str, args: Sequence[str]) -> None:
     subprocess.run([runner, *args])
 
 
@@ -107,7 +107,7 @@ def _run_main_loop(*, runner: str, runner_args: Sequence[str], delay: float) -> 
 
     now = datetime.now()
     if trigger and now - trigger > timedelta(seconds=delay):
-        _run_runner(runner, runner_args)
+        _invoke_runner(runner, runner_args)
 
         with trigger_lock:
             trigger = None

--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -98,7 +98,7 @@ def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
         now=namespace.now,
         delay=namespace.delay,
         runner=namespace.runner,
-        pytest_args=list(pytest_args)
+        pytest_args=list(pytest_args),
     )
 
 

--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -124,7 +124,6 @@ def _run_main_loop(delay, pytest_args, entrypoint) -> None:
 
 def run():
     args = _parse_arguments(sys.argv[1:])
-    print(args)
     path_to_watch = args.path
     now = args.now
 

--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -63,9 +63,7 @@ class EventHandler(events.FileSystemEventHandler):
             emit_trigger()
 
 
-def _run_entrypoint(entrypoint, *args) -> None:
-    print("args", args)
-    print("*args", *args)
+def _run_entrypoint(entrypoint, args) -> None:
     subprocess.run([entrypoint, *args])
 
 
@@ -95,7 +93,6 @@ def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
 
     namespace, pytest_args = parser.parse_known_args(args)
 
-    print(type(pytest_args))
     return ParsedArguments(
         path=namespace.path,
         now=namespace.now,
@@ -122,8 +119,6 @@ def run():
     args = _parse_arguments(sys.argv[1:])
     path_to_watch = args.path
     now = args.now
-
-    print(args.pytest_args)
 
     event_handler = EventHandler()
 

--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -3,10 +3,10 @@ import subprocess
 import sys
 import threading
 import time
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Sequence
-from dataclasses import dataclass
 
 from watchdog import events
 from watchdog.observers import Observer
@@ -102,7 +102,7 @@ def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
     )
 
 
-def _run_main_loop(delay: float, runner: str, runner_args: Sequence[str]) -> None:
+def _run_main_loop(*, runner: str, runner_args: Sequence[str], delay: float) -> None:
     global trigger
 
     now = datetime.now()
@@ -130,7 +130,9 @@ def run():
 
     try:
         while True:
-            _run_main_loop(args.delay, args.runner, args.runner_args)
+            _run_main_loop(
+                runner=args.runner, runner_args=args.runner_args, delay=args.delay
+            )
     finally:
         observer.stop()
         observer.join()

--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -21,7 +21,7 @@ class ParsedArguments:
     now: bool
     delay: float
     runner: str
-    pytest_args: Sequence[str]
+    runner_args: Sequence[str]
 
 
 def emit_trigger():
@@ -91,23 +91,23 @@ def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
         help="Use another executable to run the tests.",
     )
 
-    namespace, pytest_args = parser.parse_known_args(args)
+    namespace, runner_args = parser.parse_known_args(args)
 
     return ParsedArguments(
         path=namespace.path,
         now=namespace.now,
         delay=namespace.delay,
         runner=namespace.runner,
-        pytest_args=pytest_args,
+        runner_args=runner_args,
     )
 
 
-def _run_main_loop(delay: float, runner: str, pytest_args: Sequence[str]) -> None:
+def _run_main_loop(delay: float, runner: str, runner_args: Sequence[str]) -> None:
     global trigger
 
     now = datetime.now()
     if trigger and now - trigger > timedelta(seconds=delay):
-        _run_runner(runner, pytest_args)
+        _run_runner(runner, runner_args)
 
         with trigger_lock:
             trigger = None
@@ -130,7 +130,7 @@ def run():
 
     try:
         while True:
-            _run_main_loop(args.delay, args.runner, args.pytest_args)
+            _run_main_loop(args.delay, args.runner, args.runner_args)
     finally:
         observer.stop()
         observer.join()

--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -14,6 +14,7 @@ from watchdog.observers import Observer
 trigger_lock = threading.Lock()
 trigger = None
 
+
 @dataclass
 class ParsedArguments:
     path: Path
@@ -94,7 +95,6 @@ def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
         help="Use another executable to run the tests.",
     )
 
-
     namespace, pytest_args = parser.parse_known_args(args)
 
     return ParsedArguments(
@@ -102,9 +102,9 @@ def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
         now=namespace.now,
         delay=namespace.delay,
         entrypoint=namespace.entrypoint,
-        pytest_args=pytest_args
+        pytest_args=pytest_args,
     )
-  
+
 
 def _run_main_loop(delay, pytest_args, entrypoint) -> None:
     global trigger

--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -102,7 +102,7 @@ def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
     )
 
 
-def _run_main_loop(delay, pytest_args, runner) -> None:
+def _run_main_loop(delay, runner, pytest_args) -> None:
     global trigger
 
     now = datetime.now()
@@ -117,22 +117,20 @@ def _run_main_loop(delay, pytest_args, runner) -> None:
 
 def run():
     args = _parse_arguments(sys.argv[1:])
-    path_to_watch = args.path
-    now = args.now
 
     event_handler = EventHandler()
 
     observer = Observer()
 
-    observer.schedule(event_handler, path_to_watch, recursive=True)
+    observer.schedule(event_handler, args.path, recursive=True)
     observer.start()
 
-    if now:
+    if args.now:
         emit_trigger()
 
     try:
         while True:
-            _run_main_loop(args.delay, args.pytest_args, args.runner)
+            _run_main_loop(args.delay, args.runner, args.pytest_args)
     finally:
         observer.stop()
         observer.join()

--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -63,7 +63,7 @@ class EventHandler(events.FileSystemEventHandler):
             emit_trigger()
 
 
-def _run_runner(runner, args) -> None:
+def _run_runner(runner: str, args: Sequence[str]) -> None:
     subprocess.run([runner, *args])
 
 
@@ -98,11 +98,11 @@ def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
         now=namespace.now,
         delay=namespace.delay,
         runner=namespace.runner,
-        pytest_args=list(pytest_args),
+        pytest_args=pytest_args,
     )
 
 
-def _run_main_loop(delay, runner, pytest_args) -> None:
+def _run_main_loop(delay: float, runner: str, pytest_args: Sequence[str]) -> None:
     global trigger
 
     now = datetime.now()

--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -66,8 +66,8 @@ def _run_pytest(args) -> None:
     subprocess.run(["pytest", *args])
 
 
-def _run_entrypoint(entrypoint, *args) -> None:
-    subprocess.run([entrypoint, *args])
+def _run_entrypoint(entrypoint) -> None:
+    subprocess.run([entrypoint])
 
 
 def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
@@ -114,7 +114,7 @@ def _run_main_loop(delay, pytest_args, entrypoint) -> None:
         if not entrypoint:
             _run_pytest(pytest_args)
         else:
-            _run_entrypoint(entrypoint, pytest_args)
+            _run_entrypoint(entrypoint)
 
         with trigger_lock:
             trigger = None
@@ -124,6 +124,7 @@ def _run_main_loop(delay, pytest_args, entrypoint) -> None:
 
 def run():
     args = _parse_arguments(sys.argv[1:])
+    print(args)
     path_to_watch = args.path
     now = args.now
 

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -8,6 +8,7 @@ from pytest_mock.plugin import MockerFixture
 from watchdog import events
 
 from pytest_watcher import __version__, watcher
+from pytest_watcher.watcher import ParsedArguments
 
 
 def test_version():
@@ -110,6 +111,7 @@ def test_emit_trigger():
         ([".", "--delay=0.2", "--lf", "--nf", "-x"], ".", False, 0.2, ["--lf", "--nf", "-x"], None),
         ([".", "--lf", "--nf", "--delay=0.3", "-x"], ".", False, 0.3, ["--lf", "--nf", "-x"], None),
         (["/home/", "--entrypoint", "tox"], "/home", False, 0.5, [], "tox"),
+        (["/home/", "--entrypoint", "make test"], "/home", False, 0.5, [], "make test"),
 
     ],
 )
@@ -130,7 +132,7 @@ def test_run_main_loop_no_trigger(
 ):
     watcher.trigger = None
 
-    watcher._run_main_loop(5, ["--lf"])
+    watcher._run_main_loop(5, ["--lf"], None)
 
     mock_subprocess_run.assert_not_called()
     mock_time_sleep.assert_called_once_with(5)
@@ -145,7 +147,7 @@ def test_run_main_loop_trigger_fresh(
     watcher.trigger = datetime(2020, 1, 1, 0, 0, 0)
 
     with freeze_time("2020-01-01 00:00:04"):
-        watcher._run_main_loop(5, ["--lf"])
+        watcher._run_main_loop(5, ["--lf"], None)
 
     mock_subprocess_run.assert_not_called()
     mock_time_sleep.assert_called_once_with(5)
@@ -160,7 +162,7 @@ def test_run_main_loop_trigger(
     watcher.trigger = datetime(2020, 1, 1, 0, 0, 0)
 
     with freeze_time("2020-01-01 00:00:06"):
-        watcher._run_main_loop(5, ["--lf"])
+        watcher._run_main_loop(5, ["--lf"], None)
 
     mock_subprocess_run.assert_called_once_with(["pytest", "--lf"])
     mock_time_sleep.assert_called_once_with(5)
@@ -188,7 +190,7 @@ def test_run(
 
     mock_emit_trigger.assert_not_called()
 
-    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"])
+    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], None)
 
 
 def test_run_now(
@@ -211,4 +213,4 @@ def test_run_now(
 
     mock_emit_trigger.assert_called_once_with()
 
-    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"])
+    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], None)

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -100,7 +100,7 @@ def test_emit_trigger():
 # fmt: off
 
 @pytest.mark.parametrize(
-    ("sys_args", "path_to_watch", "now", "delay", "pytest_args", "runner"),
+    ("sys_args", "path_to_watch", "now", "delay", "runner_args", "runner"),
     [
         (["/home/"], "/home", False, 0.5, [], "pytest"),
         (["/home/", "--lf", "--nf", "-x"], "/home", False, 0.5, ["--lf", "--nf", "-x"], "pytest"),
@@ -114,14 +114,14 @@ def test_emit_trigger():
         (["/home/", "--runner", "make", "test"], "/home", False, 0.5, ["test"], "make"),
     ],
 )
-def test_parse_arguments(sys_args, path_to_watch, now, delay, pytest_args, runner):
+def test_parse_arguments(sys_args, path_to_watch, now, delay, runner_args, runner):
     _arguments = watcher._parse_arguments(sys_args)
 
     assert str(_arguments.path) == path_to_watch
     assert _arguments.now == now
     assert _arguments.delay == delay
     assert _arguments.runner == runner
-    assert _arguments.pytest_args == pytest_args
+    assert _arguments.runner_args == runner_args
 
 # fmt: on
 

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -131,7 +131,7 @@ def test_run_main_loop_no_trigger(
 ):
     watcher.trigger = None
 
-    watcher._run_main_loop(5, ["--lf"], None)
+    watcher._run_main_loop(runner="pytest", runner_args=["--lf"], delay=5)
 
     mock_subprocess_run.assert_not_called()
     mock_time_sleep.assert_called_once_with(5)
@@ -146,7 +146,7 @@ def test_run_main_loop_trigger_fresh(
     watcher.trigger = datetime(2020, 1, 1, 0, 0, 0)
 
     with freeze_time("2020-01-01 00:00:04"):
-        watcher._run_main_loop(5, ["--lf"], "pytest")
+        watcher._run_main_loop(runner="pytest", runner_args=["--lf"], delay=5)
 
     mock_subprocess_run.assert_not_called()
     mock_time_sleep.assert_called_once_with(5)
@@ -161,7 +161,7 @@ def test_run_main_loop_trigger(
     watcher.trigger = datetime(2020, 1, 1, 0, 0, 0)
 
     with freeze_time("2020-01-01 00:00:06"):
-        watcher._run_main_loop(5, "pytest", ["--lf"])
+        watcher._run_main_loop(runner="pytest", runner_args=["--lf"], delay=5)
 
     mock_subprocess_run.assert_called_once_with(["pytest", "--lf"])
     mock_time_sleep.assert_called_once_with(5)
@@ -189,7 +189,9 @@ def test_run(
 
     mock_emit_trigger.assert_not_called()
 
-    mock_run_main_loop.assert_called_once_with(0.5, "pytest", ["--lf", "--nf"])
+    mock_run_main_loop.assert_called_once_with(
+        runner="pytest", runner_args=["--lf", "--nf"], delay=0.5
+    )
 
 
 def test_run_now(
@@ -212,7 +214,9 @@ def test_run_now(
 
     mock_emit_trigger.assert_called_once_with()
 
-    mock_run_main_loop.assert_called_once_with(0.5, "pytest", ["--lf", "--nf"])
+    mock_run_main_loop.assert_called_once_with(
+        runner="pytest", runner_args=["--lf", "--nf"], delay=0.5
+    )
 
 
 @pytest.mark.parametrize("runner", [("tox"), ("'make test'")])
@@ -237,4 +241,6 @@ def test_run_runner(
 
     mock_emit_trigger.assert_called_once_with()
 
-    mock_run_main_loop.assert_called_once_with(0.5, runner, ["--lf", "--nf"])
+    mock_run_main_loop.assert_called_once_with(
+        runner=runner, runner_args=["--lf", "--nf"], delay=0.5
+    )

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -220,7 +220,7 @@ def test_run_now(
 
 
 @pytest.mark.parametrize("runner", [("tox"), ("'make test'")])
-def test_run_runner(
+def test_invoke_runner(
     mocker: MockerFixture,
     mock_observer: MagicMock,
     mock_emit_trigger: MagicMock,

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -100,7 +100,7 @@ def test_emit_trigger():
 # fmt: off
 
 @pytest.mark.parametrize(
-    ("sys_args", "path_to_watch", "now", "delay", "pytest_args", "entrypoint"),
+    ("sys_args", "path_to_watch", "now", "delay", "pytest_args", "runner"),
     [
         (["/home/"], "/home", False, 0.5, [], "pytest"),
         (["/home/", "--lf", "--nf", "-x"], "/home", False, 0.5, ["--lf", "--nf", "-x"], "pytest"),
@@ -109,18 +109,18 @@ def test_emit_trigger():
         ([".", "--lf", "--nf", "-x"], ".", False, 0.5, ["--lf", "--nf", "-x"], "pytest"),
         ([".", "--delay=0.2", "--lf", "--nf", "-x"], ".", False, 0.2, ["--lf", "--nf", "-x"], "pytest"),
         ([".", "--lf", "--nf", "--delay=0.3", "-x"], ".", False, 0.3, ["--lf", "--nf", "-x"], "pytest"),
-        (["/home/", "--entrypoint", "tox"], "/home", False, 0.5, [], "tox"),
-        (["/home/", "--entrypoint", "'make test'"], "/home", False, 0.5, [], "'make test'"),
-        (["/home/", "--entrypoint", "make", "test"], "/home", False, 0.5, ["test"], "make"),
+        (["/home/", "--runner", "tox"], "/home", False, 0.5, [], "tox"),
+        (["/home/", "--runner", "'make test'"], "/home", False, 0.5, [], "'make test'"),
+        (["/home/", "--runner", "make", "test"], "/home", False, 0.5, ["test"], "make"),
     ],
 )
-def test_parse_arguments(sys_args, path_to_watch, now, delay, pytest_args, entrypoint):
+def test_parse_arguments(sys_args, path_to_watch, now, delay, pytest_args, runner):
     _arguments = watcher._parse_arguments(sys_args)
 
     assert str(_arguments.path) == path_to_watch
     assert _arguments.now == now
     assert _arguments.delay == delay
-    assert _arguments.entrypoint == entrypoint
+    assert _arguments.runner == runner
     assert _arguments.pytest_args == pytest_args
 
 # fmt: on
@@ -215,15 +215,15 @@ def test_run_now(
     mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], "pytest")
 
 
-@pytest.mark.parametrize("entrypoint", [("tox"), ("'make test'")])
-def test_run_entrypoint(
+@pytest.mark.parametrize("runner", [("tox"), ("'make test'")])
+def test_run_runner(
     mocker: MockerFixture,
     mock_observer: MagicMock,
     mock_emit_trigger: MagicMock,
     mock_run_main_loop: MagicMock,
-    entrypoint: str,
+    runner: str,
 ):
-    args = ["ptw", ".", "--lf", "--nf", "--now", "--entrypoint", entrypoint]
+    args = ["ptw", ".", "--lf", "--nf", "--now", "--runner", runner]
 
     mocker.patch.object(sys, "argv", args)
 
@@ -237,4 +237,4 @@ def test_run_entrypoint(
 
     mock_emit_trigger.assert_called_once_with()
 
-    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], entrypoint)
+    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], runner)

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -161,7 +161,7 @@ def test_run_main_loop_trigger(
     watcher.trigger = datetime(2020, 1, 1, 0, 0, 0)
 
     with freeze_time("2020-01-01 00:00:06"):
-        watcher._run_main_loop(5, ["--lf"], "pytest")
+        watcher._run_main_loop(5, "pytest", ["--lf"])
 
     mock_subprocess_run.assert_called_once_with(["pytest", "--lf"])
     mock_time_sleep.assert_called_once_with(5)
@@ -189,7 +189,7 @@ def test_run(
 
     mock_emit_trigger.assert_not_called()
 
-    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], "pytest")
+    mock_run_main_loop.assert_called_once_with(0.5, "pytest", ["--lf", "--nf"])
 
 
 def test_run_now(
@@ -212,7 +212,7 @@ def test_run_now(
 
     mock_emit_trigger.assert_called_once_with()
 
-    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], "pytest")
+    mock_run_main_loop.assert_called_once_with(0.5, "pytest", ["--lf", "--nf"])
 
 
 @pytest.mark.parametrize("runner", [("tox"), ("'make test'")])
@@ -237,4 +237,4 @@ def test_run_runner(
 
     mock_emit_trigger.assert_called_once_with()
 
-    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], runner)
+    mock_run_main_loop.assert_called_once_with(0.5, runner, ["--lf", "--nf"])

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -100,24 +100,27 @@ def test_emit_trigger():
 # fmt: off
 
 @pytest.mark.parametrize(
-    ("sys_args", "path_to_watch", "now", "delay", "pytest_args"),
+    ("sys_args", "path_to_watch", "now", "delay", "pytest_args", "entrypoint"),
     [
-        (["/home/"], "/home", False, 0.5, []),
-        (["/home/", "--lf", "--nf", "-x"], "/home", False, 0.5, ["--lf", "--nf", "-x"]),
-        (["/home/", "--lf", "--now", "--nf", "-x"], "/home", True, 0.5, ["--lf", "--nf", "-x"]),
-        (["/home/", "--now", "--lf", "--nf", "-x"], "/home", True, 0.5, ["--lf", "--nf", "-x"]),
-        ([".", "--lf", "--nf", "-x"], ".", False, 0.5, ["--lf", "--nf", "-x"]),
-        ([".", "--delay=0.2", "--lf", "--nf", "-x"], ".", False, 0.2, ["--lf", "--nf", "-x"]),
-        ([".", "--lf", "--nf", "--delay=0.3", "-x"], ".", False, 0.3, ["--lf", "--nf", "-x"]),
+        (["/home/"], "/home", False, 0.5, [], None),
+        (["/home/", "--lf", "--nf", "-x"], "/home", False, 0.5, ["--lf", "--nf", "-x"], None),
+        (["/home/", "--lf", "--now", "--nf", "-x"], "/home", True, 0.5, ["--lf", "--nf", "-x"], None),
+        (["/home/", "--now", "--lf", "--nf", "-x"], "/home", True, 0.5, ["--lf", "--nf", "-x"], None),
+        ([".", "--lf", "--nf", "-x"], ".", False, 0.5, ["--lf", "--nf", "-x"], None),
+        ([".", "--delay=0.2", "--lf", "--nf", "-x"], ".", False, 0.2, ["--lf", "--nf", "-x"], None),
+        ([".", "--lf", "--nf", "--delay=0.3", "-x"], ".", False, 0.3, ["--lf", "--nf", "-x"], None),
+        (["/home/", "--entrypoint", "tox"], "/home", False, 0.5, [], "tox"),
+
     ],
 )
-def test_parse_arguments(sys_args, path_to_watch, now, delay, pytest_args):
-    _path, _now, _delay, _pytest_args = watcher._parse_arguments(sys_args)
+def test_parse_arguments(sys_args, path_to_watch, now, delay, pytest_args, entrypoint):
+    _arguments = watcher._parse_arguments(sys_args)
 
-    assert str(_path) == path_to_watch
-    assert _now == now
-    assert _delay == delay
-    assert _pytest_args == pytest_args
+    assert str(_arguments.path) == path_to_watch
+    assert _arguments.now == now
+    assert _arguments.delay == delay
+    assert _arguments.entrypoint == entrypoint
+    assert _arguments.pytest_args == pytest_args
 
 # fmt: on
 

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -110,8 +110,8 @@ def test_emit_trigger():
         ([".", "--delay=0.2", "--lf", "--nf", "-x"], ".", False, 0.2, ["--lf", "--nf", "-x"], "pytest"),
         ([".", "--lf", "--nf", "--delay=0.3", "-x"], ".", False, 0.3, ["--lf", "--nf", "-x"], "pytest"),
         (["/home/", "--entrypoint", "tox"], "/home", False, 0.5, [], "tox"),
-        (["/home/", "--entrypoint", "make test"], "/home", False, 0.5, [], "make test"),
-
+        (["/home/", "--entrypoint", "'make test'"], "/home", False, 0.5, [], "'make test'"),
+        (["/home/", "--entrypoint", "make", "test"], "/home", False, 0.5, ["test"], "make"),
     ],
 )
 def test_parse_arguments(sys_args, path_to_watch, now, delay, pytest_args, entrypoint):

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -102,13 +102,13 @@ def test_emit_trigger():
 @pytest.mark.parametrize(
     ("sys_args", "path_to_watch", "now", "delay", "pytest_args", "entrypoint"),
     [
-        (["/home/"], "/home", False, 0.5, [], None),
-        (["/home/", "--lf", "--nf", "-x"], "/home", False, 0.5, ["--lf", "--nf", "-x"], None),
-        (["/home/", "--lf", "--now", "--nf", "-x"], "/home", True, 0.5, ["--lf", "--nf", "-x"], None),
-        (["/home/", "--now", "--lf", "--nf", "-x"], "/home", True, 0.5, ["--lf", "--nf", "-x"], None),
-        ([".", "--lf", "--nf", "-x"], ".", False, 0.5, ["--lf", "--nf", "-x"], None),
-        ([".", "--delay=0.2", "--lf", "--nf", "-x"], ".", False, 0.2, ["--lf", "--nf", "-x"], None),
-        ([".", "--lf", "--nf", "--delay=0.3", "-x"], ".", False, 0.3, ["--lf", "--nf", "-x"], None),
+        (["/home/"], "/home", False, 0.5, [], "pytest"),
+        (["/home/", "--lf", "--nf", "-x"], "/home", False, 0.5, ["--lf", "--nf", "-x"], "pytest"),
+        (["/home/", "--lf", "--now", "--nf", "-x"], "/home", True, 0.5, ["--lf", "--nf", "-x"], "pytest"),
+        (["/home/", "--now", "--lf", "--nf", "-x"], "/home", True, 0.5, ["--lf", "--nf", "-x"], "pytest"),
+        ([".", "--lf", "--nf", "-x"], ".", False, 0.5, ["--lf", "--nf", "-x"], "pytest"),
+        ([".", "--delay=0.2", "--lf", "--nf", "-x"], ".", False, 0.2, ["--lf", "--nf", "-x"], "pytest"),
+        ([".", "--lf", "--nf", "--delay=0.3", "-x"], ".", False, 0.3, ["--lf", "--nf", "-x"], "pytest"),
         (["/home/", "--entrypoint", "tox"], "/home", False, 0.5, [], "tox"),
         (["/home/", "--entrypoint", "make test"], "/home", False, 0.5, [], "make test"),
 
@@ -146,7 +146,7 @@ def test_run_main_loop_trigger_fresh(
     watcher.trigger = datetime(2020, 1, 1, 0, 0, 0)
 
     with freeze_time("2020-01-01 00:00:04"):
-        watcher._run_main_loop(5, ["--lf"], None)
+        watcher._run_main_loop(5, ["--lf"], "pytest")
 
     mock_subprocess_run.assert_not_called()
     mock_time_sleep.assert_called_once_with(5)
@@ -161,7 +161,7 @@ def test_run_main_loop_trigger(
     watcher.trigger = datetime(2020, 1, 1, 0, 0, 0)
 
     with freeze_time("2020-01-01 00:00:06"):
-        watcher._run_main_loop(5, ["--lf"], None)
+        watcher._run_main_loop(5, ["--lf"], "pytest")
 
     mock_subprocess_run.assert_called_once_with(["pytest", "--lf"])
     mock_time_sleep.assert_called_once_with(5)
@@ -189,7 +189,7 @@ def test_run(
 
     mock_emit_trigger.assert_not_called()
 
-    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], None)
+    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], "pytest")
 
 
 def test_run_now(
@@ -212,7 +212,7 @@ def test_run_now(
 
     mock_emit_trigger.assert_called_once_with()
 
-    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], None)
+    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], "pytest")
 
 
 @pytest.mark.parametrize("entrypoint", [("tox"), ("'make test'")])

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -214,3 +214,31 @@ def test_run_now(
     mock_emit_trigger.assert_called_once_with()
 
     mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], None)
+
+
+@pytest.mark.parametrize("entrypoint", [
+    ("tox"),
+    ("'make test'")
+])
+def test_run_entrypoint(
+    mocker: MockerFixture,
+    mock_observer: MagicMock,
+    mock_emit_trigger: MagicMock,
+    mock_run_main_loop: MagicMock,
+    entrypoint: str
+):
+    args = ["ptw", ".", "--lf", "--nf", "--now", "--entrypoint", entrypoint]
+
+    mocker.patch.object(sys, "argv", args)
+
+    with pytest.raises(InterruptedError):
+        watcher.run()
+
+    mock_observer.assert_called_once_with()
+    observer_instance = mock_observer.return_value
+    observer_instance.schedule.assert_called_once()
+    observer_instance.start.assert_called_once()
+
+    mock_emit_trigger.assert_called_once_with()
+
+    mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], entrypoint)

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -215,16 +215,13 @@ def test_run_now(
     mock_run_main_loop.assert_called_once_with(0.5, ["--lf", "--nf"], None)
 
 
-@pytest.mark.parametrize("entrypoint", [
-    ("tox"),
-    ("'make test'")
-])
+@pytest.mark.parametrize("entrypoint", [("tox"), ("'make test'")])
 def test_run_entrypoint(
     mocker: MockerFixture,
     mock_observer: MagicMock,
     mock_emit_trigger: MagicMock,
     mock_run_main_loop: MagicMock,
-    entrypoint: str
+    entrypoint: str,
 ):
     args = ["ptw", ".", "--lf", "--nf", "--now", "--entrypoint", entrypoint]
 

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -8,7 +8,6 @@ from pytest_mock.plugin import MockerFixture
 from watchdog import events
 
 from pytest_watcher import __version__, watcher
-from pytest_watcher.watcher import ParsedArguments
 
 
 def test_version():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py36,py37,py38,py39,py310,py311
+envlist = py37,py38,py39,py310,py311
 
 [tox:.package]
 basepython = python3


### PR DESCRIPTION
Implements suggestion from this issue: https://github.com/olzhasar/pytest-watcher/issues/11

The commits are rather dirty, please let me know if I should squash them.

I only tested locally with Python 3.10 with the following parameters (using `pip install -e .`)

```
ptw .
ptw . --now
ptw . --now --entrypoint tox
ptw . --entrypoint tox
```