### PR TITLE
Fix typo, Continiously -> Continuously

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pytest-watcher"
 version = "0.2.5"
-description = "Continiously runs pytest on changes in *.py files"
+description = "Continuously runs pytest on changes in *.py files"
 authors = ["Olzhas Arystanov <o.arystanov@gmail.com>"]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Found via `codespell -S .mypy_cache`