### PR TITLE
Add non-py files watch support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pytest-watcher"
 version = "0.2.6"
-description = "Continuously runs pytest on changes in *.py files"
+description = "Continuously runs pytest on changes in Python projects"
 authors = ["Olzhas Arystanov <o.arystanov@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/pytest_watcher/watcher.py
+++ b/pytest_watcher/watcher.py
@@ -26,8 +26,8 @@ class ParsedArguments:
     now: bool
     delay: float
     runner: str
-    include_filter: str
-    ignore_filter: str
+    patterns: str
+    ignore_patterns: str
     runner_args: Sequence[str]
 
 
@@ -131,13 +131,13 @@ def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
         help="Use another executable to run the tests.",
     )
     parser.add_argument(
-        "--include-filter",
+        "--patterns",
         default=["*.py"],
         type=lambda f: f.split(","),
         help="Comma-separated Unix shell-style wildcard include list (default: '*.py')",
     )
     parser.add_argument(
-        "--ignore-filter",
+        "--ignore-patterns",
         default=[],
         type=lambda f: f.split(","),
         help="Comma-separated Unix shell-style wildcard ignore list (default: '')",
@@ -150,8 +150,8 @@ def _parse_arguments(args: Sequence[str]) -> ParsedArguments:
         now=namespace.now,
         delay=namespace.delay,
         runner=namespace.runner,
-        include_filter=namespace.include_filter,
-        ignore_filter=namespace.ignore_filter,
+        patterns=namespace.patterns,
+        ignore_patterns=namespace.ignore_patterns,
         runner_args=runner_args,
     )
 
@@ -172,7 +172,7 @@ def _run_main_loop(*, runner: str, runner_args: Sequence[str], delay: float) -> 
 def run():
     args = _parse_arguments(sys.argv[1:])
 
-    file_filter = FileFilter(include=args.include_filter, ignore=args.ignore_filter)
+    file_filter = FileFilter(include=args.patterns, ignore=args.ignore_patterns)
     event_handler = EventHandler(file_filter)
 
     observer = Observer()

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -1,0 +1,129 @@
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+from watchdog import events
+
+from pytest_watcher import watcher
+
+
+@pytest.mark.parametrize("event_type", watcher.EventHandler.EVENTS_WATCHED)
+def test_event_types_watched(event_type, mock_emit_trigger: MagicMock):
+    event = events.FileSystemEvent("main.py")
+    event.event_type = event_type
+
+    handler = watcher.EventHandler()
+    handler.dispatch(event)
+
+    mock_emit_trigger.assert_called_once_with()
+
+
+def test_event_types_not_watched(mock_emit_trigger: MagicMock):
+    event = events.FileClosedEvent("main.py")
+
+    handler = watcher.EventHandler()
+    handler.dispatch(event)
+
+    mock_emit_trigger.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "event_class", [events.FileSystemMovedEvent, events.FileMovedEvent]
+)
+def test_file_moved_dest_watched(event_class, mock_emit_trigger: MagicMock):
+    event = event_class("main.tmp", "main.py")
+
+    handler = watcher.EventHandler()
+    handler.dispatch(event)
+
+    mock_emit_trigger.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "event_class", [events.FileSystemMovedEvent, events.FileMovedEvent]
+)
+def test_file_moved_dest_not_watched(event_class, mock_emit_trigger: MagicMock):
+    event = event_class("main.tmp", "main.temp")
+
+    handler = watcher.EventHandler()
+    handler.dispatch(event)
+
+    mock_emit_trigger.assert_not_called()
+
+
+@pytest.mark.parametrize("path", ["main.py", "./main.py", "/home/project/main.py"])
+def test_patterns_default_watched(mock_emit_trigger: MagicMock, path: str):
+    event = events.FileCreatedEvent(path)
+
+    handler = watcher.EventHandler()
+    handler.dispatch(event)
+
+    mock_emit_trigger.assert_called_once_with()
+
+
+@pytest.mark.parametrize("path", ["main.pyc", "sqlite.db", "/home/project/file.txt"])
+def test_patterns_default_not_watched(mock_emit_trigger: MagicMock, path: str):
+    event = events.FileCreatedEvent(path)
+
+    handler = watcher.EventHandler()
+    handler.dispatch(event)
+
+    mock_emit_trigger.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("patterns", "path"),
+    [
+        (["*.txt"], "file.txt"),
+        (["main.pyc"], "main.pyc"),
+        (["/home/path/example.txt"], "/home/path/example.txt"),
+        (["*some*.txt"], "/home/path/something.txt"),
+    ],
+)
+def test_patterns_custom_watched(
+    mock_emit_trigger: MagicMock, patterns: List[str], path: str
+):
+    event = events.FileCreatedEvent(path)
+
+    handler = watcher.EventHandler(patterns=patterns)
+    handler.dispatch(event)
+
+    mock_emit_trigger.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("patterns", "path"),
+    [
+        (["*.txt"], "file.txtf"),
+        (["*.pyi", "*.pdb"], "wrong.pdf"),
+        (["/home/path/example.txt"], "/home/path/wrong.txt"),
+    ],
+)
+def test_patterns_custom_not_watched(
+    mock_emit_trigger: MagicMock, patterns: List[str], path: str
+):
+    event = events.FileCreatedEvent(path)
+
+    handler = watcher.EventHandler(patterns=patterns)
+    handler.dispatch(event)
+
+    mock_emit_trigger.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("ignore_patterns", "path"),
+    [
+        (["ignore/*.py"], "ignore/myfile.py"),
+        (["ignore/**"], "ignore/main.py"),
+        (["*pytest*"], "/home/project/pytest.yaml"),
+    ],
+)
+def test_patterns_ignore_not_watched(
+    mock_emit_trigger: MagicMock, ignore_patterns: List[str], path: str
+):
+    event = events.FileCreatedEvent(path)
+
+    handler = watcher.EventHandler(ignore_patterns=ignore_patterns)
+    handler.dispatch(event)
+
+    mock_emit_trigger.assert_not_called()

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -130,7 +130,7 @@ def test_emit_trigger():
 # fmt: off
 
 @pytest.mark.parametrize(
-    ("sys_args", "path_to_watch", "now", "delay", "runner_args", "runner", "include_filter", "ignore_filter"),
+    ("sys_args", "path_to_watch", "now", "delay", "runner_args", "runner", "patterns", "ignore_patterns"),
     [
         (["/home/"], "/home", False, 0.5, [], "pytest", ['*.py'], []),
         (["/home/", "--lf", "--nf", "-x"], "/home", False, 0.5, ["--lf", "--nf", "-x"], "pytest", ['*.py'], []),
@@ -142,19 +142,19 @@ def test_emit_trigger():
         (["/home/", "--runner", "tox"], "/home", False, 0.5, [], "tox", ['*.py'], []),
         (["/home/", "--runner", "'make test'"], "/home", False, 0.5, [], "'make test'", ['*.py'], []),
         (["/home/", "--runner", "make", "test"], "/home", False, 0.5, ["test"], "make", ['*.py'], []),
-        (["/home/", "--include-filter", "*.py,*.env"], "/home", False, 0.5, [], "pytest", ['*.py', '*.env'], []),
-        (["/home/", "--include-filter=*.py,*.env", "--ignore-filter", "long-long-long-path,templates/*.py"], "/home", False, 0.5, [], "pytest", ['*.py', '*.env'], ["long-long-long-path", "templates/*.py"]),
+        (["/home/", "--patterns", "*.py,*.env"], "/home", False, 0.5, [], "pytest", ['*.py', '*.env'], []),
+        (["/home/", "--patterns=*.py,*.env", "--ignore-patterns", "long-long-long-path,templates/*.py"], "/home", False, 0.5, [], "pytest", ['*.py', '*.env'], ["long-long-long-path", "templates/*.py"]),
     ],
 )
-def test_parse_arguments(sys_args, path_to_watch, now, delay, runner_args, runner, include_filter, ignore_filter):
+def test_parse_arguments(sys_args, path_to_watch, now, delay, runner_args, runner, patterns, ignore_patterns):
     _arguments = watcher._parse_arguments(sys_args)
 
     assert str(_arguments.path) == path_to_watch
     assert _arguments.now == now
     assert _arguments.delay == delay
     assert _arguments.runner == runner
-    assert _arguments.include_filter == include_filter
-    assert _arguments.ignore_filter == ignore_filter
+    assert _arguments.patterns == patterns
+    assert _arguments.ignore_patterns == ignore_patterns
     assert _arguments.runner_args == runner_args
 
 # fmt: on

--- a/tests/test_pytest_watcher.py
+++ b/tests/test_pytest_watcher.py
@@ -54,12 +54,12 @@ def _release_trigger():
             "/home/project/pytest.yaml",
             FileFilter(include=["*.yaml"], ignore=["./pytest*"]),
             True,
-        ),  # Can be contrintuitive -> next line correct ignore
+        ),
         (
             "/home/project/pytest.yaml",
             FileFilter(include=["*.yaml"], ignore=["*pytest*"]),
             False,
-        ),  # Can be contrintuitive
+        ),
     ],
 )
 def test_file_filter(filepath, file_filter, expected):


### PR DESCRIPTION
Hello! 

Thank you very much for the simple and working `pytest-watcher` solution!

I've missed a little functionality about filtering watch files above `*.py`. Because in my projects also `.env` and `.ini` files can widely change the behaviour.

I added arguments to the command line now. In my case, it is okay as it. In future, we can also put some of these `--include-filter` and `--ignore-filter` arguments to the configuration file.

And I also have small doubts about confusing examples. But for now, I have no idea how to make it more clear except documentation remark. https://github.com/olzhasar/pytest-watcher/compare/master...aptakhin:pytest-watcher:add-other-extensions-support#diff-58fb153a128d801a5a58c94d9fcd912af6349faa66d202cc43ec4e1c23ae25dfR54-R62


