### PR TITLE
fix: prevent argparse from eating up abbreviated args that should be passed to the runner

### DIFF
--- a/pytest_watcher/parse.py
+++ b/pytest_watcher/parse.py
@@ -15,6 +15,7 @@ def parse_arguments(args: Sequence[str]) -> Tuple[argparse.Namespace, List[str]]
             Watch the <path> for file changes and trigger the test runner (pytest).\n
             Additional arguments are passed directly to the test runner.
         """,
+        allow_abbrev=False,
     )
     parser.add_argument("path", type=Path, help="The path to watch for file changes.")
     parser.add_argument(

--- a/tests/test_parse_arguments.py
+++ b/tests/test_parse_arguments.py
@@ -77,7 +77,8 @@ def test_ignore_patterns(args: List[str], ignore_patterns: List[str]):
         ([".", "--lf", "--nf", "-vv"], ["--lf", "--nf", "-vv"]),
         ([".", "--runner", "tox", "--lf", "--nf", "-vv"], ["--lf", "--nf", "-vv"]),
         ([".", "--lf", "--nf", "-vv", "--runner", "tox"], ["--lf", "--nf", "-vv"]),
-        ([".", "--ignore", "tests/test_watcher.py"], ["--ignore", "tests/test_watcher.py"]),
+        ([".", 
+          "--ignore", "tests/test_watcher.py"], ["--ignore", "tests/test_watcher.py"]),
     ],
 )
 def test_runner_args(args: List[str], runner_args: List[str]):

--- a/tests/test_parse_arguments.py
+++ b/tests/test_parse_arguments.py
@@ -77,8 +77,10 @@ def test_ignore_patterns(args: List[str], ignore_patterns: List[str]):
         ([".", "--lf", "--nf", "-vv"], ["--lf", "--nf", "-vv"]),
         ([".", "--runner", "tox", "--lf", "--nf", "-vv"], ["--lf", "--nf", "-vv"]),
         ([".", "--lf", "--nf", "-vv", "--runner", "tox"], ["--lf", "--nf", "-vv"]),
-        ([".", 
-          "--ignore", "tests/test_watcher.py"], ["--ignore", "tests/test_watcher.py"]),
+        (
+            [".", "--ignore", "tests/test_watcher.py"],
+            ["--ignore", "tests/test_watcher.py"],
+        ),
     ],
 )
 def test_runner_args(args: List[str], runner_args: List[str]):

--- a/tests/test_parse_arguments.py
+++ b/tests/test_parse_arguments.py
@@ -77,11 +77,12 @@ def test_ignore_patterns(args: List[str], ignore_patterns: List[str]):
         ([".", "--lf", "--nf", "-vv"], ["--lf", "--nf", "-vv"]),
         ([".", "--runner", "tox", "--lf", "--nf", "-vv"], ["--lf", "--nf", "-vv"]),
         ([".", "--lf", "--nf", "-vv", "--runner", "tox"], ["--lf", "--nf", "-vv"]),
+        ([".", "--ignore", "tests/test_watcher.py"], ["--ignore", "tests/test_watcher.py"]),
     ],
 )
 def test_runner_args(args: List[str], runner_args: List[str]):
-    _, runner_args = parse_arguments(args)
-    assert runner_args == runner_args
+    _, parsed_args = parse_arguments(args)
+    assert parsed_args == runner_args
 
 
 def test_version(capsys: pytest.CaptureFixture):


### PR DESCRIPTION
`argparse` optimistically shortens arguments when things are unambigous.

This means that `--ignore /some/pattern` will get matched to `--ignore-patterns /some/pattern`. This is not the intended behavior when trying to pass `--ignore` to pytest.

This PR:
- Fixes this problem by forcing the argument parser to be strict.
- Fixes the `test_parse_arguments` unit test, which wasn't really testing anything.
- Adds a unit test to ensure new behavor.

All tests pass.

