### PR TITLE
watchdog 5.x compatibility

### DIFF
--- a/pytest_watcher/event_handler.py
+++ b/pytest_watcher/event_handler.py
@@ -46,7 +46,7 @@ class EventHandler:
             # For file moved type events we are also interested in the destination
             paths.append(event.dest_path)
 
-        return match_any_paths(paths, self.patterns, self.ignore_patterns)
+        return match_any_paths(paths, included_patterns=self.patterns, excluded_patterns=self.ignore_patterns)
 
     def dispatch(self, event: events.FileSystemEvent) -> None:
         if self._is_event_watched(event):


### PR DESCRIPTION
New installs fail with: 
```
TypeError: match_any_paths() takes 1 positional argument but 3 were given
```

This project specifies watchdog >= 2.0.0, so the new 5.x version is picked up.
This has some breaking changes, including enforcement of keyword-arguments.
Looks like nothing else is effected. Should also still work with older watchdog version, kwarg names have not changed.